### PR TITLE
Add condition check before installing apps lists

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -72,10 +72,22 @@ renew_cert() {
     cd $install_dir
 }
 
+install_neutrinet_apps_list() {
+    if ! sudo yunohost app listlists | grep -q "neutrinet:"; then
+      sudo yunohost app fetchlist -n neutrinet -u https://neutrinet.be/apps.json
+    fi
+}
+
+install_labriqueinternet_apps_list() {
+    if ! sudo yunohost app listlists | grep -q "labriqueinternet :"; then
+      sudo yunohost app fetchlist -n labriqueinternet -u https://labriqueinter.net/apps/labriqueinternet.json
+    fi
+}
+
 sudo yunohost app setting neutrinet version -v "0.2"
 
-sudo yunohost app fetchlist -n neutrinet -u https://neutrinet.be/apps.json
-sudo yunohost app fetchlist -n labriqueinternet -u https://labriqueinter.net/apps/labriqueinternet.json
+install_neutrinet_apps_list
+install_labriqueinternet_apps_list
 
 get_out_of_testing
 


### PR DESCRIPTION
Looks like `sudo yunohost app fetchlist -n name -u https://...` now
returns an error when there's already an apps list named `name`.

This cause the install script to fail when trying to add a list named
`labriqueinternet` on a Cube that already has one.

I'm not sure if this behavior is new to Yunohost 2.6, but I started
noticing the problem since 2.6.

This quick fix attempts to determine if a list named `name` already
exists by grepping on `name:` in the output of `listlists`. This is not
robust since it does rely on the output format of the command which
might change.

@Psycojoker Thoughts on this? Is there a better/cleaner way? Should I bump the script version or add an upgrade step here? (I guess I shouldn't, but double-checking with you)