### PR TITLE
Upgrade to 0.2.2

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -15,12 +15,24 @@ fi
 
 # 0.2 -> 0.2.1
 if [[ "$version" == "0.2" ]]; then
-
-    get_out_of_testing
-
     sudo yunohost app setting neutrinet version -v "0.2.1"
     version="0.2.1"
 
-    cd /opt/neutrinet/renew_cert
+    cd $RENEW_CERT_PATH
     sudo ve/bin/python renew_from_cube.py
+fi
+
+# 0.2.1 -> 0.2.2
+if [[ "$version" == "0.2.1" ]]; then
+    sudo yunohost app setting neutrinet version -v "0.2.2"
+    version="0.2.2"
+
+    cd $RENEW_CERT_PATH
+    sudo ve/bin/python renew_from_cube.py
+
+    cat <<EOF > /etc/cron.daily/neutrinet-renew-cert.sh
+#!/bin/bash
+cd $RENEW_CERT_PATH && ve/bin/python renew_from_cube.py
+EOF
+    chmod 0755 /etc/cron.daily/neutrinet-renew-cert.sh
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -28,16 +28,15 @@ if [[ "$version" == "0.2.1" ]]; then
     version="0.2.2"
 
     cd $RENEW_CERT_PATH
-    git checkout master
-    git pull origin master
+    sudo git fetch
+    sudo git checkout 01b9306e51e74a2dac5b06f3fb6c29a0fb2fe755
     sudo ve/bin/python renew_from_cube.py --cron
 
     cat <<EOF > /etc/cron.daily/neutrinet-renew-cert
 #!/bin/bash
 cd $RENEW_CERT_PATH
-git checkout master
-git pull origin master
 ve/bin/python renew_from_cube.py --cron
 EOF
-    chmod 0755 /etc/cron.daily/neutrinet-renew-cert
+    sudo chown root:root /etc/cron.daily/neutrinet-renew-cert
+    sudo chmod 0755 /etc/cron.daily/neutrinet-renew-cert
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -28,12 +28,16 @@ if [[ "$version" == "0.2.1" ]]; then
     version="0.2.2"
 
     cd $RENEW_CERT_PATH
+    git checkout master
     git pull origin master
     sudo ve/bin/python renew_from_cube.py --cron
 
     cat <<EOF > /etc/cron.daily/neutrinet-renew-cert
 #!/bin/bash
-cd $RENEW_CERT_PATH && git pull origin master && ve/bin/python renew_from_cube.py --cron
+cd $RENEW_CERT_PATH
+git checkout master
+git pull origin master
+ve/bin/python renew_from_cube.py --cron
 EOF
     chmod 0755 /etc/cron.daily/neutrinet-renew-cert
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -28,11 +28,12 @@ if [[ "$version" == "0.2.1" ]]; then
     version="0.2.2"
 
     cd $RENEW_CERT_PATH
-    sudo ve/bin/python renew_from_cube.py
+    git pull origin master
+    sudo ve/bin/python renew_from_cube.py --cron
 
     cat <<EOF > /etc/cron.daily/neutrinet-renew-cert
 #!/bin/bash
-cd $RENEW_CERT_PATH && ve/bin/python renew_from_cube.py
+cd $RENEW_CERT_PATH && git pull origin master && ve/bin/python renew_from_cube.py --cron
 EOF
     chmod 0755 /etc/cron.daily/neutrinet-renew-cert
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,9 +30,9 @@ if [[ "$version" == "0.2.1" ]]; then
     cd $RENEW_CERT_PATH
     sudo ve/bin/python renew_from_cube.py
 
-    cat <<EOF > /etc/cron.daily/neutrinet-renew-cert.sh
+    cat <<EOF > /etc/cron.daily/neutrinet-renew-cert
 #!/bin/bash
 cd $RENEW_CERT_PATH && ve/bin/python renew_from_cube.py
 EOF
-    chmod 0755 /etc/cron.daily/neutrinet-renew-cert.sh
+    chmod 0755 /etc/cron.daily/neutrinet-renew-cert
 fi


### PR DESCRIPTION
What this upgrade does:
- `git pull` the latest version of `renew_cert` (to use the `--cron` flag)
- renew the certificate
- add a daily cron job that will check if the certificate must be
  renewed

The `renew_from_cube` script only renew the cert if it will [expire in less than 4
months](https://github.com/Neutrinet/renew_cert/blob/master/renew_from_cube.py#L29) (thanks to the `--cron` arg).